### PR TITLE
ドメインロジックの初期実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "typing-backend",
+  "version": "0.1.0",
+  "description": "Core domain logic for the typing backend service.",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "node --test",
+    "lint": "node ./scripts/lint.js"
+  },
+  "keywords": [
+    "typing",
+    "backend",
+    "contest",
+    "leaderboard"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { readdirSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function collectJsFiles(dir) {
+  const result = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      result.push(...collectJsFiles(full));
+    } else if (stats.isFile() && extname(full) === '.js') {
+      result.push(full);
+    }
+  }
+  return result;
+}
+
+const roots = ['src', 'tests'];
+let files = [];
+for (const root of roots) {
+  try {
+    files = files.concat(collectJsFiles(root));
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.error(`ディレクトリ ${root} の走査中にエラー:`, error);
+      process.exitCode = 1;
+    }
+  }
+}
+
+if (files.length === 0) {
+  console.log('チェック対象の JavaScript ファイルが見つかりません。');
+  process.exit(0);
+}
+
+for (const file of files) {
+  const res = spawnSync(process.execPath, ['--check', file], {
+    stdio: 'inherit'
+  });
+  if (res.status !== 0) {
+    process.exit(res.status ?? 1);
+  }
+}
+
+console.log('Lint (構文チェック) 完了');

--- a/src/domain/contest.js
+++ b/src/domain/contest.js
@@ -1,0 +1,101 @@
+/**
+ * コンテストに関するドメインロジック。
+ */
+
+/**
+ * @typedef {Object} Contest
+ * @property {string} id
+ * @property {string} title
+ * @property {string} visibility
+ * @property {string} startsAt ISO8601 文字列
+ * @property {string} endsAt ISO8601 文字列
+ * @property {number} timeLimitSec
+ * @property {number} maxAttempts
+ * @property {boolean} allowBackspace
+ * @property {string} leaderboardVisibility
+ */
+
+const STATUS = /** @type {const} */ (['scheduled', 'running', 'finished']);
+
+/**
+ * 現在時刻からコンテスト状態を判定する。
+ * @param {Contest} contest
+ * @param {Date} now
+ * @returns {typeof STATUS[number]}
+ */
+export function getContestStatus(contest, now = new Date()) {
+  const start = new Date(contest.startsAt);
+  const end = new Date(contest.endsAt);
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+    throw new Error('startsAt が不正な日付です。');
+  }
+  if (!(end instanceof Date) || Number.isNaN(end.getTime())) {
+    throw new Error('endsAt が不正な日付です。');
+  }
+  if (now < start) return 'scheduled';
+  if (now >= end) return 'finished';
+  return 'running';
+}
+
+/**
+ * ランキングが閲覧可能かどうかを判定する。
+ *
+ * @param {Contest} contest
+ * @param {Date} now
+ * @returns {boolean}
+ */
+export function isLeaderboardVisible(contest, now = new Date()) {
+  const visibility = contest.leaderboardVisibility;
+  if (visibility === 'hidden') return false;
+  if (visibility === 'during') return true;
+  if (visibility === 'after') {
+    return getContestStatus(contest, now) === 'finished';
+  }
+  return false;
+}
+
+/**
+ * セッション開始が許可されるか検証する。
+ *
+ * @param {Contest} contest
+ * @param {{attemptsUsed:number}} entry エントリー情報
+ * @param {Date} now
+ * @returns {{ok:true} | {ok:false, reason:string}}
+ */
+export function validateSessionStart(contest, entry, now = new Date()) {
+  const status = getContestStatus(contest, now);
+  if (status === 'scheduled') {
+    return { ok: false, reason: 'コンテストはまだ開始されていません。' };
+  }
+  if (status === 'finished') {
+    return { ok: false, reason: 'コンテストは終了しています。' };
+  }
+  if (!entry) {
+    return { ok: false, reason: 'エントリーが必要です。' };
+  }
+  if (entry.attemptsUsed >= contest.maxAttempts) {
+    return { ok: false, reason: '試行回数の上限に達しました。' };
+  }
+  return { ok: true };
+}
+
+/**
+ * 参加コードが必要かどうか。
+ * @param {Contest} contest
+ * @returns {boolean}
+ */
+export function requiresJoinCode(contest) {
+  return contest.visibility === 'private';
+}
+
+/**
+ * 指定ユーザーの残り試行回数を計算する。
+ *
+ * @param {Contest} contest
+ * @param {{attemptsUsed:number}|undefined} entry
+ * @returns {number}
+ */
+export function remainingAttempts(contest, entry) {
+  if (!entry) return contest.maxAttempts;
+  return Math.max(0, contest.maxAttempts - entry.attemptsUsed);
+}

--- a/src/domain/leaderboard.js
+++ b/src/domain/leaderboard.js
@@ -1,0 +1,49 @@
+/**
+ * リーダーボードの順位計算ロジック。
+ */
+
+const compareSessions = (a, b) => {
+  if (a.score !== b.score) return b.score - a.score;
+  if (a.accuracy !== b.accuracy) return b.accuracy - a.accuracy;
+  if (a.cpm !== b.cpm) return b.cpm - a.cpm;
+  const aTime = new Date(a.endedAt).getTime();
+  const bTime = new Date(b.endedAt).getTime();
+  return aTime - bTime;
+};
+
+/**
+ * @param {Array<{sessionId:string,userId:string,username?:string,score:number,accuracy:number,cpm:number,endedAt:string}>} sessions
+ * @returns {{ranked:Array<{rank:number,sessionId:string,userId:string,username?:string,score:number,accuracy:number,cpm:number,endedAt:string}>, summary:{top:Array, total:number}}}
+ */
+export function buildLeaderboard(sessions) {
+  const sorted = [...sessions].sort(compareSessions);
+  let lastRank = 0;
+  let lastComparable = null;
+  let index = 0;
+  const ranked = sorted.map((session) => {
+    index += 1;
+    const comparable = [session.score, session.accuracy, session.cpm, new Date(session.endedAt).getTime()];
+    if (!lastComparable || comparable.some((value, i) => value !== lastComparable[i])) {
+      lastRank = index;
+      lastComparable = comparable;
+    }
+    return { ...session, rank: lastRank };
+  });
+  return {
+    ranked,
+    summary: {
+      top: ranked.slice(0, 10),
+      total: sessions.length
+    }
+  };
+}
+
+/**
+ * 自分の順位情報を抽出するヘルパー。
+ *
+ * @param {ReturnType<typeof buildLeaderboard>['ranked']} ranked
+ * @param {string} userId
+ */
+export function extractPersonalRank(ranked, userId) {
+  return ranked.find((item) => item.userId === userId) ?? null;
+}

--- a/src/domain/scoring.js
+++ b/src/domain/scoring.js
@@ -1,0 +1,92 @@
+/**
+ * タイピング計測の数値を計算する純粋関数群。
+ * ここでは e-typing 互換の初期仕様（CPM, WPM, Accuracy, Score）を実装する。
+ */
+
+/**
+ * @typedef {Object} TypingStats
+ * @property {number} cpm 1分あたりの正タイプ数
+ * @property {number} wpm 1分あたりの単語数
+ * @property {number} accuracy 正確率（0〜1）
+ * @property {number} score スコア（整数）
+ * @property {number} correct 正タイプ数
+ * @property {number} mistakes ミスタイプ数
+ * @property {number} elapsedMs 経過ミリ秒
+ */
+
+/**
+ * 正タイプ・ミスタイプ・経過時間からスコア指標を算出する。
+ * @param {number} correct 正タイプ数
+ * @param {number} mistakes ミスタイプ数
+ * @param {number} elapsedMs 経過ミリ秒
+ * @returns {TypingStats}
+ */
+export function calculateTypingStats(correct, mistakes, elapsedMs) {
+  if (correct < 0 || mistakes < 0) {
+    throw new Error('正タイプ数とミスタイプ数は0以上である必要があります。');
+  }
+  if (elapsedMs <= 0) {
+    return {
+      cpm: 0,
+      wpm: 0,
+      accuracy: mistakes === 0 ? 1 : 0,
+      score: 0,
+      correct,
+      mistakes,
+      elapsedMs
+    };
+  }
+  const elapsedMinutes = elapsedMs / 60000;
+  const total = correct + mistakes;
+  const accuracy = total === 0 ? 1 : correct / total;
+  const cpm = correct / elapsedMinutes;
+  const wpm = cpm / 5;
+  const score = Math.floor(cpm * (accuracy ** 2) / 2);
+  return { cpm, wpm, accuracy, score, correct, mistakes, elapsedMs };
+}
+
+/**
+ * クライアントの申告値とサーバ計算値の乖離を評価する。
+ * 乖離が閾値を超える場合は不正またはバグの可能性がある。
+ *
+ * @param {TypingStats} expected サーバが再計算した値
+ * @param {{cpm:number,wpm:number,accuracy:number,score:number}} reported クライアント申告値
+ * @param {{cpm?:number,wpm?:number,accuracy?:number,score?:number}} [tolerance]
+ * @returns {{ok:boolean, deltas:Record<string, number>}}
+ */
+export function compareReportedStats(expected, reported, tolerance = {}) {
+  const delta = {};
+  let ok = true;
+  const keys = ['cpm', 'wpm', 'accuracy', 'score'];
+  for (const key of keys) {
+    const expectedValue = expected[key];
+    const reportedValue = reported?.[key];
+    if (typeof reportedValue !== 'number' || Number.isNaN(reportedValue)) {
+      ok = false;
+      delta[key] = Infinity;
+      continue;
+    }
+    const diff = Math.abs(expectedValue - reportedValue);
+    delta[key] = diff;
+    const tol = tolerance[key] ?? (key === 'accuracy' ? 0.02 : key === 'score' ? 1 : 1);
+    if (diff > tol) {
+      ok = false;
+    }
+  }
+  return { ok, deltas: delta };
+}
+
+/**
+ * 精度表示のためのフォーマッタ。テスト容易性のため純粋関数で提供する。
+ *
+ * @param {TypingStats} stats
+ * @returns {{cpm:string,wpm:string,accuracy:string,score:string}}
+ */
+export function formatStats(stats) {
+  return {
+    cpm: stats.cpm.toFixed(2),
+    wpm: stats.wpm.toFixed(2),
+    accuracy: (stats.accuracy * 100).toFixed(2) + '%',
+    score: stats.score.toString()
+  };
+}

--- a/src/domain/session.js
+++ b/src/domain/session.js
@@ -1,0 +1,185 @@
+import { calculateTypingStats, compareReportedStats } from './scoring.js';
+
+const BACKSPACE_KEYS = new Set(['Backspace', 'BACKSPACE', 'BackspaceKey', 'KeyBackspace']);
+const MAX_KEYSTROKES = 2000;
+
+/**
+ * @typedef {Object} KeylogEntry
+ * @property {number} t セッション開始からの相対ミリ秒
+ * @property {string} k 押下キー
+ */
+
+/**
+ * キーログから正タイプ数・ミス数・完了状況を復元する。
+ *
+ * @param {{typingTarget:string,keylog:KeylogEntry[],allowBackspace:boolean}} params
+ * @returns {{correct:number,mistakes:number,completed:boolean,durationMs:number,issues:string[],forbiddenBackspaceCount:number,processed:number}}
+ */
+export function replayKeylog({ typingTarget, keylog, allowBackspace }) {
+  if (typeof typingTarget !== 'string') {
+    throw new Error('typingTarget は文字列である必要があります。');
+  }
+  if (!Array.isArray(keylog)) {
+    throw new Error('keylog は配列である必要があります。');
+  }
+  let pointer = 0; // 正しく確定した文字数
+  let mistakes = 0;
+  let forbiddenBackspaceCount = 0;
+  let lastTime = 0;
+  let firstTime = null;
+  const issues = [];
+  const targetLength = typingTarget.length;
+  const processed = keylog.length;
+  if (processed > MAX_KEYSTROKES) {
+    issues.push('KEY_LIMIT_EXCEEDED');
+  }
+
+  for (let i = 0; i < keylog.length; i += 1) {
+    const entry = keylog[i];
+    if (!entry || typeof entry.t !== 'number' || !Number.isFinite(entry.t)) {
+      issues.push('INVALID_TIMESTAMP');
+      continue;
+    }
+    if (entry.t < 0) {
+      issues.push('NEGATIVE_TIMESTAMP');
+      continue;
+    }
+    if (firstTime === null) firstTime = entry.t;
+    if (entry.t < lastTime) {
+      issues.push('TIMESTAMP_NOT_SORTED');
+    }
+    lastTime = Math.max(lastTime, entry.t);
+    const key = String(entry.k ?? '');
+    if (BACKSPACE_KEYS.has(key)) {
+      if (allowBackspace) {
+        pointer = Math.max(0, pointer - 1);
+      } else {
+        forbiddenBackspaceCount += 1;
+        mistakes += 1;
+      }
+      continue;
+    }
+    if (pointer >= targetLength) {
+      mistakes += 1;
+      continue;
+    }
+    const expected = typingTarget[pointer];
+    if (key === expected) {
+      pointer += 1;
+    } else {
+      mistakes += 1;
+    }
+  }
+  const durationMs = keylog.length === 0 ? 0 : Math.max(0, lastTime - (firstTime ?? 0));
+  const completed = pointer >= targetLength && targetLength > 0 ? true : pointer >= targetLength;
+  const correct = pointer;
+  return { correct, mistakes, completed, durationMs, issues, forbiddenBackspaceCount, processed };
+}
+
+/**
+ * キー間隔の統計値を計算する。
+ * @param {KeylogEntry[]} keylog
+ * @returns {{mean:number,stdev:number,cv:number,count:number}}
+ */
+export function analyseIntervals(keylog) {
+  if (!Array.isArray(keylog) || keylog.length < 2) {
+    return { mean: 0, stdev: 0, cv: 0, count: Math.max(0, keylog ? keylog.length - 1 : 0) };
+  }
+  const intervals = [];
+  let last = keylog[0].t;
+  for (let i = 1; i < keylog.length; i += 1) {
+    const current = keylog[i].t;
+    if (typeof current !== 'number' || !Number.isFinite(current) || typeof last !== 'number') {
+      continue;
+    }
+    const diff = current - last;
+    if (diff >= 0) {
+      intervals.push(diff);
+    }
+    last = current;
+  }
+  if (intervals.length === 0) {
+    return { mean: 0, stdev: 0, cv: 0, count: 0 };
+  }
+  const mean = intervals.reduce((sum, value) => sum + value, 0) / intervals.length;
+  const variance = intervals.reduce((sum, value) => sum + ((value - mean) ** 2), 0) / intervals.length;
+  const stdev = Math.sqrt(variance);
+  const cv = mean === 0 ? Infinity : stdev / mean;
+  return { mean, stdev, cv, count: intervals.length };
+}
+
+/**
+ * セッション完了リクエストを検証・再計算する。
+ *
+ * @param {Object} params
+ * @param {Object} params.contest
+ * @param {Object} params.prompt
+ * @param {Object} params.payload クライアント申告値
+ * @param {{attemptsUsed:number}} params.entry
+ * @param {Date} [params.now]
+ * @returns {{status:'finished'|'expired'|'dq', stats:ReturnType<typeof calculateTypingStats>, issues:string[], anomaly:{mean:number,stdev:number,cv:number,count:number},flags:Object}}
+ */
+export function evaluateSessionFinish({ contest, prompt, payload, entry, now = new Date() }) {
+  if (!contest || !prompt || !payload) {
+    throw new Error('contest, prompt, payload は必須です。');
+  }
+  const additionalIssues = [];
+  if (!entry || typeof entry.attemptsUsed !== 'number') {
+    additionalIssues.push('ENTRY_NOT_FOUND');
+  }
+  const flags = {
+    pasteBlocked: payload?.clientFlags?.pasteBlocked ?? false,
+    defocus: payload?.clientFlags?.defocus ?? 0
+  };
+  const { correct, mistakes, completed, durationMs, issues, forbiddenBackspaceCount } = replayKeylog({
+    typingTarget: prompt.typingTarget,
+    keylog: payload.keylog ?? [],
+    allowBackspace: contest.allowBackspace
+  });
+  const elapsedMs = Math.max(durationMs, 1);
+  const stats = calculateTypingStats(correct, mistakes, elapsedMs);
+  const comparison = compareReportedStats(stats, {
+    cpm: payload.cpm,
+    wpm: payload.wpm,
+    accuracy: payload.accuracy,
+    score: payload.score
+  }, {
+    cpm: 1.5,
+    wpm: 1.5,
+    accuracy: 0.05,
+    score: 2
+  });
+  additionalIssues.push(...issues);
+  if (payload.errors !== undefined && Math.abs(payload.errors - mistakes) > 1) {
+    additionalIssues.push('ERROR_COUNT_MISMATCH');
+  }
+  if (!comparison.ok) {
+    additionalIssues.push('METRIC_MISMATCH');
+  }
+  if (!completed && prompt.typingTarget.length > 0) {
+    additionalIssues.push('PROMPT_NOT_COMPLETED');
+  }
+  if (forbiddenBackspaceCount > 0) {
+    additionalIssues.push('BACKSPACE_FORBIDDEN');
+  }
+
+  const timeLimitMs = contest.timeLimitSec * 1000;
+  if (durationMs > timeLimitMs + 1000) { // 許容1秒の通信誤差
+    additionalIssues.push('TIME_LIMIT_EXCEEDED');
+  }
+
+  const anomaly = analyseIntervals(payload.keylog ?? []);
+  if (anomaly.cv !== 0 && anomaly.cv < 0.1 && anomaly.count > 10) {
+    additionalIssues.push('LOW_VARIANCE_TYPING');
+  }
+
+  let status = 'finished';
+  if (!completed) {
+    status = 'expired';
+  }
+  const disqualifyingIssues = ['METRIC_MISMATCH', 'KEY_LIMIT_EXCEEDED', 'BACKSPACE_FORBIDDEN'];
+  if (additionalIssues.some((issue) => disqualifyingIssues.includes(issue))) {
+    status = 'dq';
+  }
+  return { status, stats, issues: additionalIssues, anomaly, flags };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+export { calculateTypingStats, compareReportedStats, formatStats } from './domain/scoring.js';
+export { getContestStatus, isLeaderboardVisible, validateSessionStart, requiresJoinCode, remainingAttempts } from './domain/contest.js';
+export { replayKeylog, analyseIntervals, evaluateSessionFinish } from './domain/session.js';
+export { buildLeaderboard, extractPersonalRank } from './domain/leaderboard.js';

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -1,0 +1,223 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  calculateTypingStats,
+  compareReportedStats,
+  formatStats,
+  getContestStatus,
+  isLeaderboardVisible,
+  validateSessionStart,
+  requiresJoinCode,
+  remainingAttempts,
+  replayKeylog,
+  analyseIntervals,
+  evaluateSessionFinish,
+  buildLeaderboard,
+  extractPersonalRank
+} from '../src/index.js';
+
+test('calculateTypingStats: 正確な計算が行われる', () => {
+  const result = calculateTypingStats(120, 30, 60000);
+  assert.equal(result.cpm, 120);
+  assert.equal(result.wpm, 24);
+  assert.equal(result.accuracy, 0.8);
+  assert.equal(result.score, Math.floor(120 * (0.8 ** 2) / 2));
+});
+
+test('compareReportedStats: 乖離を検知する', () => {
+  const expected = calculateTypingStats(100, 0, 60000);
+  const match = compareReportedStats(expected, expected);
+  assert.ok(match.ok);
+  const mismatch = compareReportedStats(expected, { cpm: 50, wpm: 10, accuracy: 0.5, score: 10 });
+  assert.ok(!mismatch.ok);
+});
+
+test('formatStats: 表示用文字列を生成する', () => {
+  const formatted = formatStats(calculateTypingStats(50, 5, 30000));
+  assert.equal(formatted.cpm.endsWith('00'), true);
+  assert.equal(formatted.accuracy.endsWith('%'), true);
+});
+
+test('getContestStatus: 状態遷移を判定する', () => {
+  const contest = {
+    id: '1',
+    title: '秋の腕試し',
+    visibility: 'public',
+    startsAt: '2025-10-01T09:00:00+09:00',
+    endsAt: '2025-10-07T23:59:59+09:00',
+    timeLimitSec: 60,
+    maxAttempts: 3,
+    allowBackspace: false,
+    leaderboardVisibility: 'during'
+  };
+  const before = getContestStatus(contest, new Date('2025-09-30T10:00:00+09:00'));
+  const during = getContestStatus(contest, new Date('2025-10-02T10:00:00+09:00'));
+  const after = getContestStatus(contest, new Date('2025-10-08T00:00:00+09:00'));
+  assert.equal(before, 'scheduled');
+  assert.equal(during, 'running');
+  assert.equal(after, 'finished');
+});
+
+test('isLeaderboardVisible respects visibility policy', () => {
+  const baseContest = {
+    id: '1',
+    title: '秋の腕試し',
+    visibility: 'public',
+    startsAt: '2025-10-01T09:00:00+09:00',
+    endsAt: '2025-10-07T23:59:59+09:00',
+    timeLimitSec: 60,
+    maxAttempts: 3,
+    allowBackspace: false,
+    leaderboardVisibility: 'during'
+  };
+  assert.equal(isLeaderboardVisible(baseContest, new Date('2025-10-03T10:00:00+09:00')), true);
+  const afterContest = { ...baseContest, leaderboardVisibility: 'after' };
+  assert.equal(isLeaderboardVisible(afterContest, new Date('2025-10-03T10:00:00+09:00')), false);
+  assert.equal(isLeaderboardVisible(afterContest, new Date('2025-10-08T10:00:00+09:00')), true);
+  const hiddenContest = { ...baseContest, leaderboardVisibility: 'hidden' };
+  assert.equal(isLeaderboardVisible(hiddenContest, new Date('2025-10-08T10:00:00+09:00')), false);
+});
+
+test('validateSessionStart enforces attempt limits', () => {
+  const contest = {
+    id: '1',
+    title: '秋の腕試し',
+    visibility: 'public',
+    startsAt: '2025-10-01T09:00:00+09:00',
+    endsAt: '2025-10-07T23:59:59+09:00',
+    timeLimitSec: 60,
+    maxAttempts: 3,
+    allowBackspace: false,
+    leaderboardVisibility: 'during'
+  };
+  const entry = { attemptsUsed: 2 };
+  const ok = validateSessionStart(contest, entry, new Date('2025-10-02T10:00:00+09:00'));
+  assert.ok(ok.ok);
+  const ng = validateSessionStart(contest, { attemptsUsed: 3 }, new Date('2025-10-02T10:00:00+09:00'));
+  assert.ok(!ng.ok);
+});
+
+test('replayKeylog correctly counts mistakes and backspace usage', () => {
+  const prompt = { typingTarget: 'abc' };
+  const keylog = [
+    { t: 0, k: 'a' },
+    { t: 430, k: 'x' },
+    { t: 870, k: 'b' },
+    { t: 1150, k: 'Backspace' },
+    { t: 1450, k: 'b' },
+    { t: 1760, k: 'c' }
+  ];
+  const result = replayKeylog({ typingTarget: prompt.typingTarget, keylog, allowBackspace: true });
+  assert.equal(result.correct, 3);
+  assert.equal(result.mistakes, 1);
+  assert.equal(result.completed, true);
+  assert.equal(result.durationMs, 1760);
+});
+
+test('evaluateSessionFinish flags illegal backspace when not allowed', () => {
+  const contest = {
+    id: '1',
+    title: '本番',
+    visibility: 'public',
+    startsAt: '2025-10-01T09:00:00+09:00',
+    endsAt: '2025-10-07T23:59:59+09:00',
+    timeLimitSec: 60,
+    maxAttempts: 3,
+    allowBackspace: false,
+    leaderboardVisibility: 'during'
+  };
+  const prompt = { typingTarget: 'ab' };
+  const keylog = [
+    { t: 0, k: 'a' },
+    { t: 300, k: 'Backspace' },
+    { t: 600, k: 'a' },
+    { t: 900, k: 'b' }
+  ];
+  const replay = replayKeylog({ typingTarget: prompt.typingTarget, keylog, allowBackspace: false });
+  const stats = calculateTypingStats(replay.correct, replay.mistakes, Math.max(replay.durationMs, 1));
+  const payload = {
+    cpm: stats.cpm,
+    wpm: stats.wpm,
+    accuracy: stats.accuracy,
+    score: stats.score,
+    errors: replay.mistakes,
+    keylog,
+    clientFlags: { pasteBlocked: true, defocus: 0 }
+  };
+  const result = evaluateSessionFinish({ contest, prompt, payload, entry: { attemptsUsed: 1 } });
+  assert.equal(result.status, 'dq');
+  assert.ok(result.issues.includes('BACKSPACE_FORBIDDEN'));
+});
+
+test('evaluateSessionFinish accepts valid run', () => {
+  const contest = {
+    id: '1',
+    title: '練習会',
+    visibility: 'public',
+    startsAt: '2025-10-01T09:00:00+09:00',
+    endsAt: '2025-10-07T23:59:59+09:00',
+    timeLimitSec: 60,
+    maxAttempts: 5,
+    allowBackspace: true,
+    leaderboardVisibility: 'during'
+  };
+  const prompt = { typingTarget: 'romaji' };
+  const keylog = [
+    { t: 0, k: 'r' },
+    { t: 310, k: 'o' },
+    { t: 660, k: 'm' },
+    { t: 1000, k: 'a' },
+    { t: 1500, k: 'j' },
+    { t: 2150, k: 'i' }
+  ];
+  const replay = replayKeylog({ typingTarget: prompt.typingTarget, keylog, allowBackspace: true });
+  const stats = calculateTypingStats(replay.correct, replay.mistakes, Math.max(replay.durationMs, 1));
+  const payload = {
+    cpm: stats.cpm,
+    wpm: stats.wpm,
+    accuracy: stats.accuracy,
+    score: stats.score,
+    errors: replay.mistakes,
+    keylog,
+    clientFlags: { pasteBlocked: true, defocus: 0 }
+  };
+  const result = evaluateSessionFinish({ contest, prompt, payload, entry: { attemptsUsed: 2 } });
+  assert.equal(result.status, 'finished');
+  assert.deepEqual(result.issues, []);
+  assert.ok(result.anomaly.cv > 0);
+});
+
+test('analyseIntervals detects low variance typing', () => {
+  const keylog = Array.from({ length: 12 }, (_, i) => ({ t: i * 100, k: 'a' }));
+  const anomaly = analyseIntervals(keylog);
+  assert.equal(anomaly.cv, 0);
+});
+
+test('buildLeaderboard sorts and assigns ranks', () => {
+  const sessions = [
+    { sessionId: 's1', userId: 'u1', username: 'Alice', score: 500, accuracy: 0.95, cpm: 400, endedAt: '2025-10-01T10:00:00Z' },
+    { sessionId: 's2', userId: 'u2', username: 'Bob', score: 520, accuracy: 0.92, cpm: 390, endedAt: '2025-10-01T09:50:00Z' },
+    { sessionId: 's3', userId: 'u3', username: 'Carol', score: 500, accuracy: 0.97, cpm: 410, endedAt: '2025-10-01T09:55:00Z' }
+  ];
+  const { ranked, summary } = buildLeaderboard(sessions);
+  assert.equal(ranked[0].sessionId, 's2');
+  assert.equal(ranked[1].sessionId, 's3');
+  assert.equal(ranked[2].sessionId, 's1');
+  assert.equal(ranked[1].rank, 2);
+  assert.equal(summary.total, 3);
+  const me = extractPersonalRank(ranked, 'u3');
+  assert.equal(me.rank, 2);
+});
+
+test('remainingAttempts calculates remaining tries', () => {
+  const contest = { maxAttempts: 5 };
+  const entry = { attemptsUsed: 2 };
+  assert.equal(remainingAttempts(contest, entry), 3);
+  assert.equal(remainingAttempts(contest, undefined), 5);
+});
+
+test('requiresJoinCode returns true for private contests', () => {
+  assert.equal(requiresJoinCode({ visibility: 'private' }), true);
+  assert.equal(requiresJoinCode({ visibility: 'public' }), false);
+});


### PR DESCRIPTION
## Summary
- タイピング統計計算・セッション再評価・リーダーボード順位付けなどのドメイン関数を追加
- コンテスト状態判定やセッション検証ロジックに基づくテストケースを用意
- npm scripts と簡易構文チェックスクリプトを整備

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceacf9075483239f01d0302923e6bd