### PR TITLE
Docker を利用した PostgreSQL 開発 DB の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM postgres:16-alpine
+
+ENV POSTGRES_DB=typing \
+    POSTGRES_USER=typing \
+    POSTGRES_PASSWORD=typing
+
+EXPOSE 5432
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=5 \
+  CMD pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" || exit 1

--- a/README.md
+++ b/README.md
@@ -24,6 +24,54 @@ HOST=0.0.0.0
 CORS_ORIGIN=http://localhost:5173
 ```
 
+## Docker を利用したデータベースの起動
+
+このリポジトリには PostgreSQL 16 (Alpine) ベースの Docker イメージを構築するための `Dockerfile` が含まれています。開発用途でローカルの
+データベースを簡単に用意したい場合に利用してください。
+
+### 1. イメージのビルド
+
+```
+docker build -t typing-backend-db .
+```
+
+### 2. 環境変数の準備
+
+コンテナ起動時に利用するデータベース名・ユーザー名・パスワードを `.env.db` などのファイルで定義します。Dockerfile には開発向けの
+デフォルト値（`typing` ユーザー／データベース／パスワード）が設定されていますが、以下のように上書きすることもできます。
+
+```
+POSTGRES_DB=typing
+POSTGRES_USER=typing
+POSTGRES_PASSWORD=typing
+```
+
+### 3. コンテナの起動
+
+永続化用ボリュームを作成し、ポート 5432 をホストに公開した状態で PostgreSQL を起動します。
+
+```
+docker volume create typing-backend-db-data
+docker run --name typing-backend-db \
+  --env-file .env.db \
+  -p 5432:5432 \
+  -v typing-backend-db-data:/var/lib/postgresql/data \
+  typing-backend-db
+```
+
+コンテナが起動したら、アプリケーション側の `DATABASE_URL` を `postgres://<ユーザー>:<パスワード>@localhost:5432/<データベース>` に設定
+すれば接続できます。
+
+### 4. 終了とログ確認
+
+```
+docker stop typing-backend-db
+docker start typing-backend-db    # 再開
+docker logs -f typing-backend-db  # ログを監視
+```
+
+ボリューム (`typing-backend-db-data`) を削除しない限り、データベースの内容は保持されます。
+
 ## 起動
 
 ```


### PR DESCRIPTION
## Summary
- PostgreSQL 16 (Alpine) ベースの Dockerfile を追加し、開発向けのデフォルト環境変数とヘルスチェックを定義
- README に Docker イメージのビルド方法とコンテナ管理手順を追記

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced6519ee883239823ed5055500587