### PR TITLE
Zod v4 importへの移行

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "fastify-type-provider-zod": "^5.1.0",
         "pg": "^8.11.3",
         "socket.io": "^4.8.1",
-        "zod": "^3.22.4"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fastify-type-provider-zod": "^5.1.0",
     "pg": "^8.11.3",
     "socket.io": "^4.8.1",
-    "zod": "^3.22.4"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,5 +1,5 @@
 import { Pool, type PoolClient, type PoolConfig } from 'pg';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const envConfigSchema = z.object({
   DATABASE_URL: z.string().url().optional(),

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,5 +1,5 @@
 import { config as loadEnv } from 'dotenv';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 loadEnv();
 

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import type { FastifyZodPlugin } from '../fastifyTypes.js';
 

--- a/src/server/routes/contests.ts
+++ b/src/server/routes/contests.ts
@@ -6,7 +6,7 @@ import {
   SessionStatus as PrismaSessionStatus
 } from '@prisma/client';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { type ContestStatus, getContestStatus, isLeaderboardVisible, requiresJoinCode } from '../../domain/contest.js';
 import { buildLeaderboard, extractPersonalRank } from '../../domain/leaderboard.js';

--- a/src/server/routes/prompts.ts
+++ b/src/server/routes/prompts.ts
@@ -1,5 +1,5 @@
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import type { FastifyZodPlugin } from '../fastifyTypes.js';
 
 const promptResponseSchema = z.object({

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -1,5 +1,5 @@
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { buildLeaderboard, extractPersonalRank } from '../../domain/leaderboard.js';
 import { ConflictError, NotFoundError, ValidationError } from '../../services/typingStore.js';
 import type { FastifyZodPlugin } from '../fastifyTypes.js';


### PR DESCRIPTION
## 概要
- Zod の import を `zod/v4` に統一し、fastify-type-provider-zod と同じ実装を参照するようにしました。
- 依存関係のバージョン指定を更新し、Zod v4 エントリポイントを確実に利用できるようにしました。

## テスト
- npm run build
- npm test *(テストファイルのグロブが解決できず失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68ceda48cb3c8323977d9523c7772933