### PR TITLE
Seed default admin user during migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ e-typing 風タイピングゲームのバックエンドです。ドメイン�
    PORT=3000
    HOST=0.0.0.0
    CORS_ORIGIN=http://localhost:5173
+   ADMIN_USERNAME=admin           # 省略時は "admin"
+   ADMIN_EMAIL=admin@example.com  # 省略時は "admin@example.com"
+   ADMIN_PASSWORD=change-me       # 省略時は "change-me"
    ```
+   - マイグレーション適用時に管理者ユーザーが存在しない場合、自動で `ADMIN_*` の値を使って1件作成します。
+   - パスワードは初期化直後に必ず変更してください。
 3. Prisma でスキーマを適用
    ```bash
    npx prisma migrate dev --name init  # 開発で初期マイグレーションを作成・適用


### PR DESCRIPTION
## Summary
- データベースマイグレーションの完了後に管理者ユーザーが存在しない場合、自動で1件作成する処理を追加
- 環境変数 `ADMIN_*` で自動作成される管理者ユーザーの認証情報を上書きできるようにし、README に設定方法を追記

## Testing
- npm test (パターンがマッチせず失敗)
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef8db66fc8323a1634e95142db62f