### PR TITLE
サーバー起動前にマイグレーションを実行する

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ e-typing 風タイピングゲームのバックエンドです。ドメイン�
    ```
    - マイグレーション適用時に管理者ユーザーが存在しない場合、自動で `ADMIN_*` の値を使って1件作成します。
    - パスワードは初期化直後に必ず変更してください。
-3. Prisma でスキーマを適用
+3. Prisma Client を生成
    ```bash
-   npx prisma migrate dev --name init  # 開発で初期マイグレーションを作成・適用
-   npx prisma generate                  # Prisma Client を生成
-   npx prisma migrate deploy            # CI / 本番でマイグレーションを適用
+   npx prisma generate
    ```
+   - サーバー起動時に `src/db/migrations.ts` が自動で実行され、テーブルが存在しない場合は作成されます。
+   - 管理者ユーザーが存在しない場合は `ADMIN_*` の環境変数を元に1件自動作成されます。
+   - Prisma のスキーマを変更した際は、必要に応じて `npx prisma migrate dev` などでマイグレーションファイルを作成してください。
 
 ## Docker で PostgreSQL を使う
 

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,9 +1,31 @@
+import { createPool } from '../db/client.js';
+import { applyMigrations } from '../db/migrations.js';
 import { buildServer } from './buildServer.js';
 import { getServerConfig } from './config.js';
 import { createDependencies } from './dependencies.js';
 
+async function migrateDatabase(): Promise<void> {
+  const pool = createPool();
+  try {
+    await applyMigrations(pool);
+  } finally {
+    try {
+      await pool.end();
+    } catch (closeError) {
+      console.error('マイグレーション用のDB接続のクローズに失敗しました', closeError);
+    }
+  }
+}
+
 async function main() {
   const config = getServerConfig();
+  try {
+    await migrateDatabase();
+  } catch (error) {
+    console.error('データベースマイグレーションの適用に失敗しました', error);
+    process.exit(1);
+    return;
+  }
   const dependencies = createDependencies(config);
   const server = await buildServer({ config, dependencies });
   try {


### PR DESCRIPTION
## 概要
- サーバー起動前に PostgreSQL へ接続してマイグレーションと管理者ユーザーの作成を自動実行
- マイグレーション処理後に接続をクローズし、失敗時には明示的にプロセスを終了
- README を更新し、起動時にスキーマ適用と管理者作成が自動化されることを明記

## テスト
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cefddc71108323b0f4ee4a25999d08